### PR TITLE
Add support for running ffmpeg in a different directory - cwd

### DIFF
--- a/ffmpeg.html
+++ b/ffmpeg.html
@@ -9,7 +9,7 @@
 
       ffmpegSettings.cmdPath = /ffmpeg/i.test(cmdPath) ? cmdPath.trim() : defaults.cmdPath;
 
-      ffmpegSettings.cwdPath = /\./i.test(cwdPath) ? cwdPath.trim() : defaults.cwdPath;
+      ffmpegSettings.cwdPath = cwdPath?.trim() ? cwdPath.trim() : defaults.cwdPath;
 
       ffmpegSettings.cmdOutputsMax = Number.isInteger(cmdOutputsMax) && cmdOutputsMax > 5 ? cmdOutputsMax : defaults.cmdOutputsMax;
 

--- a/ffmpeg.html
+++ b/ffmpeg.html
@@ -1,13 +1,15 @@
 <script type="text/javascript">
   const FFMPEG = (() => {
-    const defaults = { cmdPath: 'ffmpeg', cmdOutputsMax: 5, secretType: 'text' };
+    const defaults = { cmdPath: 'ffmpeg', cwdPath: '.', cmdOutputsMax: 5, secretType: 'text' };
 
     const { ffmpeg: ffmpegSettings } = RED.settings;
 
     if (ffmpegSettings instanceof Object) {
-      const { cmdPath, cmdOutputsMax, secretType } = ffmpegSettings;
+      const { cmdPath, cwdPath, cmdOutputsMax, secretType } = ffmpegSettings;
 
       ffmpegSettings.cmdPath = /ffmpeg/i.test(cmdPath) ? cmdPath.trim() : defaults.cmdPath;
+
+      ffmpegSettings.cwdPath = /\./i.test(cwdPath) ? cwdPath.trim() : defaults.cwdPath;
 
       ffmpegSettings.cmdOutputsMax = Number.isInteger(cmdOutputsMax) && cmdOutputsMax > 5 ? cmdOutputsMax : defaults.cmdOutputsMax;
 
@@ -40,6 +42,10 @@
           return cmdPath === '' || /^\s*$|ffmpeg/i.test(cmdPath);
         },
       },
+      cwdPath: {
+        value: FFMPEG.cwdPath,
+      },
+
       cmdArgs: {
         value: JSON.stringify(['-version']),
         validate: function (cmdArgs) {
@@ -95,6 +101,17 @@
           this.value = this.value.trim();
 
           this.title = this.value || cmdPathPlaceholder;
+        });
+
+      const cwdPathPlaceholder = FFMPEG.cwdPath;
+
+      const cwdPath = $('#node-input-cwdPath')
+        .prop('placeholder', cwdPathPlaceholder)
+        .prop('title', this.cwdPath || cwdPathPlaceholder)
+        .on('input', function () {
+          this.value = this.value.trim();
+
+          this.title = this.value || cwdPathPlaceholder;
         });
 
       const cmdArgs = $('#node-input-cmdArgs')
@@ -166,6 +183,13 @@
     <div class="form-row">
       <label for="node-input-cmdPath"><i class="fa fa-terminal"></i> Path</label>
       <input type="text" id="node-input-cmdPath" />
+    </div>
+
+    <p class="form-tips">Path to start the ffmpeg process in.</p>
+
+    <div class="form-row">
+      <label for="node-input-cwdPath"><i class="fa fa-folder"></i> Start in</label>
+      <input type="text" id="node-input-cwdPath" />
     </div>
 
     <p class="form-tips">Array of arguments passed to the ffmpeg process.</p>

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -17,7 +17,7 @@ module.exports = RED => {
 
       ffmpegSettings.cmdPath = /ffmpeg/i.test(cmdPath) ? cmdPath.trim() : defaults.cmdPath;
 	  
-	  ffmpegSettings.cwdPath = /\./i.test(cwdPath) ? cwdPath.trim() : defaults.cwdPath;
+      ffmpegSettings.cwdPath = cwdPath?.trim() ? cwdPath.trim() : defaults.cwdPath;
 
       ffmpegSettings.cmdOutputsMax = Number.isInteger(cmdOutputsMax) && cmdOutputsMax > 5 ? cmdOutputsMax : defaults.cmdOutputsMax;
 

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -10,12 +10,14 @@ module.exports = RED => {
   } = RED;
 
   const FFMPEG = (() => {
-    const defaults = { cmdPath: 'ffmpeg', cmdOutputsMax: 5, secretType: 'text' };
+    const defaults = { cmdPath: 'ffmpeg', cwdPath: '.', cmdOutputsMax: 5, secretType: 'text' };
 
     if (ffmpegSettings instanceof Object) {
-      const { cmdPath, cmdOutputsMax, secretType } = ffmpegSettings;
+      const { cmdPath, cwdPath, cmdOutputsMax, secretType } = ffmpegSettings;
 
       ffmpegSettings.cmdPath = /ffmpeg/i.test(cmdPath) ? cmdPath.trim() : defaults.cmdPath;
+	  
+	  ffmpegSettings.cwdPath = /\./i.test(cwdPath) ? cwdPath.trim() : defaults.cwdPath;
 
       ffmpegSettings.cmdOutputsMax = Number.isInteger(cmdOutputsMax) && cmdOutputsMax > 5 ? cmdOutputsMax : defaults.cmdOutputsMax;
 
@@ -41,6 +43,8 @@ module.exports = RED => {
         this.stopping = false;
 
         this.cmdPath = config.cmdPath.trim() || FfmpegNode.cmdPath;
+		
+		this.cwdPath = config.cwdPath.trim() || FfmpegNode.cwdPath;
 
         this.cmdArgs = config.cmdArgs ? FfmpegNode.jsonParse(config.cmdArgs) : ['-version'];
 
@@ -49,6 +53,8 @@ module.exports = RED => {
         this.killSignal = ['SIGHUP', 'SIGINT', 'SIGKILL', 'SIGTERM'].includes(config.killSignal) ? config.killSignal : 'SIGTERM';
 
         FfmpegNode.validateCmdPath(this.cmdPath); // throws
+		
+		FfmpegNode.validateCwdPath(this.cwdPath); // throws
 
         FfmpegNode.validateCmdArgs(this.cmdArgs); // throws
 
@@ -107,11 +113,11 @@ module.exports = RED => {
       }
 
       if (typeof action === 'object') {
-        const { command, signal, path, args, env } = action;
+        const { command, signal, path, cwd, args, env } = action;
 
         switch (command) {
           case 'start':
-            this.start(payload, path, args, env, filename);
+            this.start(payload, path, cwd, args, env, filename);
 
             break;
 
@@ -123,7 +129,7 @@ module.exports = RED => {
           case 'restart':
             await this.stop(signal);
 
-            this.start(payload, path, args, env, filename);
+            this.start(payload, path, cwd, args, env, filename);
 
             break;
 
@@ -149,13 +155,19 @@ module.exports = RED => {
       done();
     }
 
-    start(payload, cmdPath, cmdArgs, cmdEnv, outFilenames) {
+    start(payload, cmdPath, cwdPath, cmdArgs, cmdEnv, outFilenames) {
       if (!this.running) {
         try {
           if (typeof cmdPath !== 'undefined') {
             FfmpegNode.validateCmdPath(cmdPath); // throws
           } else {
             cmdPath = this.cmdPath;
+          }
+
+          if (typeof cwdPath !== 'undefined') {
+            FfmpegNode.validateCwdPath(cwdPath); // throws
+          } else {
+            cwdPath = this.cwdPath;
           }
 
           if (typeof cmdArgs !== 'undefined') {
@@ -172,7 +184,7 @@ module.exports = RED => {
 
           const env = typeof cmdEnv === 'object' ? { ...process.env, ...cmdEnv } : process.env;
 
-          const ffmpeg = spawn(cmdPath, cmdArgs, { stdio, env });
+          const ffmpeg = spawn(cmdPath, cmdArgs, { cwd: cwdPath, stdio, env });
 
           ffmpeg.once('error', err => {
             this.error(err);
@@ -373,6 +385,13 @@ module.exports = RED => {
       }
     }
 
+    static validateCwdPath(cwdPath) {
+      if (typeof cwdPath !== 'string') {
+        throw new Error(_('ffmpeg.error.cwd_path_invalid', { cwdPath }));
+      }
+    }
+
+
     static validateCmdArgs(cmdArgs) {
       if (!Array.isArray(cmdArgs)) {
         throw new Error(_('ffmpeg.error.cmd_args_invalid', { cmdArgs }));
@@ -395,6 +414,8 @@ module.exports = RED => {
   }
 
   FfmpegNode.cmdPath = FFMPEG.cmdPath;
+  
+  FfmpegNode.cwdPath = FFMPEG.cwdPath;
 
   FfmpegNode.cmdOutputsMax = FFMPEG.cmdOutputsMax;
 

--- a/ffmpeg.js
+++ b/ffmpeg.js
@@ -44,7 +44,7 @@ module.exports = RED => {
 
         this.cmdPath = config.cmdPath.trim() || FfmpegNode.cmdPath;
 		
-		this.cwdPath = config.cwdPath.trim() || FfmpegNode.cwdPath;
+        this.cwdPath = config.cwdPath.trim() || FfmpegNode.cwdPath;
 
         this.cmdArgs = config.cmdArgs ? FfmpegNode.jsonParse(config.cmdArgs) : ['-version'];
 
@@ -54,7 +54,7 @@ module.exports = RED => {
 
         FfmpegNode.validateCmdPath(this.cmdPath); // throws
 		
-		FfmpegNode.validateCwdPath(this.cwdPath); // throws
+        FfmpegNode.validateCwdPath(this.cwdPath); // throws
 
         FfmpegNode.validateCmdArgs(this.cmdArgs); // throws
 

--- a/locales/en-US/ffmpeg.html
+++ b/locales/en-US/ffmpeg.html
@@ -27,7 +27,7 @@
       <ul>
         <li>starts the ffmpeg process</li>
         <li>has no effect if it is already running</li>
-        <li>optional properties: path, args</li>
+        <li>optional properties: path, cwd, args</li>
         <li>
           send an input <code>msg</code> structured as:
           <pre class="form-tips" style="min-width: 450px"><code>
@@ -35,6 +35,7 @@
   action: {
     command: 'start'
     // path: 'ffmpeg',
+    // cwd: '/opt/videos',
     // args: ['-loglevel', 'trace', '-version'],
   }
 }
@@ -66,7 +67,7 @@
       <ul>
         <li>restarts the ffmpeg process</li>
         <li>convenience command that triggers stop followed by start</li>
-        <li>optional properties: signal, path, args</li>
+        <li>optional properties: signal, path, cwd, args</li>
         <li>
           send an input <code>msg</code> structured as:
           <pre class="form-tips" style="min-width: 450px"><code>
@@ -75,6 +76,7 @@
     command: 'restart',
     // signal: 'SIGKILL'
     // path: 'ffmpeg',
+    // cwd: '/opt/videos',
     // args: ['-loglevel', 'trace', '-version']
   }
 }
@@ -91,6 +93,9 @@
         <dt class="optional">path<span class="property-type">string</span></dt>
         <dd>example: '/home/pi/.node-red/node_modules/ffmpeg-for-homebridge/ffmpeg'</dd>
         <dd>Path to the ffmpeg binary executable.</dd>
+        <dt class="optional">cwd<span class="property-type">string</span></dt>
+        <dd>example: '/opt/videos'</dd>
+        <dd>Path to start the ffmpeg process in.</dd>		
         <dt class="optional">args<span class="property-type">array</span></dt>
         <dd>example: ['-loglevel', 'trace', '-version']</dd>
         <dd>Array of arguments passed to the ffmpeg process.</dd>
@@ -187,6 +192,14 @@
           </ul>
         </li>
         <li>
+          <h5>Start in</h5>
+          <ul>
+            <li>path to start the ffmpeg process in.</li>
+            <li>can be overridden via the input message</li>
+            <li>default can be set in settings.js</li>
+          </ul>
+        </li>
+        <li>
           <h5>Args</h5>
           <ul>
             <li>array of arguments passed to the ffmpeg process</li>
@@ -233,6 +246,19 @@
       </ul>
     </li>
     <li>
+      <h4><code>cwdPath</code></h4>
+      <ul>
+        <li>default path to start the process in</li>
+        <li>defaults to: '.' (node-red base dir)</li>
+      </ul>
+    </li>
+    <li>
+      <h4><code>cmdPath</code></h4>
+      <ul>
+        <li>default path to ffmpeg</li>
+        <li>defaults to: 'ffmpeg'</li>
+      </ul>
+    </li>    <li>
       <h4><code>cmdOutputsMax</code></h4>
       <ul>
         <li>maximum stdio outputs</li>

--- a/locales/en-US/ffmpeg.html
+++ b/locales/en-US/ffmpeg.html
@@ -258,7 +258,8 @@
         <li>default path to ffmpeg</li>
         <li>defaults to: 'ffmpeg'</li>
       </ul>
-    </li>    <li>
+    </li>
+    <li>
       <h4><code>cmdOutputsMax</code></h4>
       <ul>
         <li>maximum stdio outputs</li>

--- a/locales/en-US/ffmpeg.json
+++ b/locales/en-US/ffmpeg.json
@@ -12,6 +12,7 @@
     },
     "error": {
       "cmd_path_invalid": "cmdPath \"__cmdPath__\" is invalid",
+	  "cwd_path_invalid": "cwdPath \"__cwdPath__\" is invalid",
       "cmd_args_invalid": "cmdArgs \"__cmdArgs__\" is invalid",
       "cmd_outputs_invalid": "cmdOutputs \"__cmdOutputs__\" is invalid",
       "cmd_topics_invalid": "cmdTopics \"__cmdTopics__\" is invalid"

--- a/locales/en-US/ffmpeg.json
+++ b/locales/en-US/ffmpeg.json
@@ -12,7 +12,7 @@
     },
     "error": {
       "cmd_path_invalid": "cmdPath \"__cmdPath__\" is invalid",
-	  "cwd_path_invalid": "cwdPath \"__cwdPath__\" is invalid",
+      "cwd_path_invalid": "cwdPath \"__cwdPath__\" is invalid",
       "cmd_args_invalid": "cmdArgs \"__cmdArgs__\" is invalid",
       "cmd_outputs_invalid": "cmdOutputs \"__cmdOutputs__\" is invalid",
       "cmd_topics_invalid": "cmdTopics \"__cmdTopics__\" is invalid"


### PR DESCRIPTION
Hi Kevin,

Firstly thanks for creating this useful node.

I needed to be able to start ffmpeg in a specified path (for 'ffmpeg -report' to dump it's output somewhere sensible), so I have extended your node to include this functionality.

I am not much of a coder, so I hope these changes are satisfactory. I think it would be great to have this part of your upstream. Please let me know your feedback or suggestions.

Thanks,
Radek